### PR TITLE
Issue 2 - load command first draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 `go build` will create the `infomodels` binary.
+
+### How to load data
+
+```
+go build && go install &&  infomodels --model pedsnet-core --modelv 2.3.0 load -s nemours_pedsnet -d 'postgresql://localhost:5433/pedsnet_dcc_v23?sslmode=disable' ~/Documents/PEDSnet/testdata
+```
+
+A little bit fussy. If you run it twice in a row, it will abort since it won't be able to create tables the second time around.  There is no revert/undo feature yet.

--- a/cmd/constrain.go
+++ b/cmd/constrain.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/infomodels/database"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"time"
+)
+
+var constrainCmd = &cobra.Command{
+	Use:   "constrain [flags]",
+	Short: "add constraints to a data model instance",
+	Long: `Add foreign key constraints to a data model instance.
+
+Add foreign key constraints to the data model instance located in the
+database specified by the dburi switch and further specified by the
+searchPath switch. The model and model version are looked up in the
+database in the version_history table.
+
+The required searchPath switch is a PostgreSQL search_path value
+containing a comma-separated list of schema names. The first schema in
+the list is the primary schema in which the constraints will be
+added. Additional schemas may be required if the tables have
+foreign keys into tables located in other schemas.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+
+		var (
+			db           *database.Database
+			dburi        string
+			searchPath   string
+			dmsaservice  string
+			dataModel    string
+			modelVersion string
+			err          error
+		)
+
+		// Enforce required dburi.
+		dburi = viper.GetString("dburi")
+		if dburi == "" {
+			log.Fatal("constrain requires a dburi")
+		}
+
+		// Enforce required searchPath.
+		searchPath = viper.GetString("searchPath")
+		if searchPath == "" {
+			log.Fatal("constrain requires a searchPath")
+		}
+
+		dmsaservice = viper.GetString("dmsaservice")
+
+		dataModel, modelVersion, err = getModelAndVersion(dburi, searchPath)
+		if err != nil {
+			log.WithFields(log.Fields{"err": err.Error()}).Fatal("Failed to get model and version")
+		}
+
+		if viper.GetString("model") != "" {
+			dataModel = viper.GetString("model")
+		}
+
+		if viper.GetString("modelv") != "" {
+			modelVersion = viper.GetString("modelv")
+		}
+
+		logFields := log.Fields{
+			"dataModel":    dataModel,
+			"modelVersion": modelVersion,
+			"dburi":        dburi,
+			"searchPath":   searchPath,
+			"dmsaservice":  dmsaservice,
+		}
+
+		db, err = database.Open(dataModel, modelVersion, dburi, searchPath, dmsaservice, "", "")
+		if err != nil {
+			logFields["err"] = err.Error()
+			log.WithFields(logFields).Fatal("Database Open failed")
+		}
+
+		// TODO: add switches for database error sensitivities (normal/strict/force)
+
+		if !viper.GetBool("undo") {
+
+			log.WithFields(logFields).Info("adding foreign key constraints")
+
+			constraintsStart := time.Now()
+			err = db.CreateConstraints("normal")
+			if err != nil {
+				elapsed := time.Since(constraintsStart)
+				logFields["durationMinutes"] = elapsed.Minutes()
+				logFields["err"] = err.Error()
+				log.WithFields(logFields).Fatal("error while adding constraints")
+			}
+
+			elapsed := time.Since(constraintsStart)
+			logFields["durationMinutes"] = elapsed.Minutes()
+			log.WithFields(logFields).Info("constraints added")
+
+		} else {
+
+			// Drop constraints
+			log.WithFields(logFields).Info("dropping constraints")
+
+			constraintsStart := time.Now()
+			err = db.DropConstraints("normal")
+			if err != nil {
+				elapsed := time.Since(constraintsStart)
+				logFields["durationMinutes"] = elapsed.Minutes()
+				logFields["err"] = err.Error()
+				log.WithFields(logFields).Fatal("error while dropping constraints")
+			}
+
+			elapsed := time.Since(constraintsStart)
+			logFields["durationMinutes"] = elapsed.Minutes()
+			log.WithFields(logFields).Info("constraints dropped")
+
+		}
+
+	},
+}
+
+func init() {
+
+	// Register this command under the top-level CLI command.
+	RootCmd.AddCommand(constrainCmd)
+
+	// Made these into global flags because I couldn't figure out how to use them in another subcommand also.
+	// // Set up the constrain-command-specific flags.
+	// constrainCmd.Flags().StringP("dburi", "d", "", "Database URI. Required.")
+	// //	constrainCmd.Flags().StringP("dbpass", "p", "", "Database password.")
+	// constrainCmd.Flags().StringP("searchPath", "s", "", "SearchPath indicating primary and optional secondary schemas. Required.")
+	// constrainCmd.Flags().Bool("undo", false, "Undo/drop all constraints.")
+
+	// // Bind viper keys to the flag values.
+	// viper.BindPFlag("dburi", constrainCmd.Flags().Lookup("dburi"))
+	// //	viper.BindPFlag("dbpass", constrainCmd.Flags().Lookup("dbpass"))
+	// viper.BindPFlag("searchPath", constrainCmd.Flags().Lookup("searchPath"))
+	// viper.BindPFlag("undo", constrainCmd.Flags().Lookup("undo"))
+}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
 	"github.com/infomodels/database"
 	"github.com/infomodels/datadirectory"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var loadCmd = &cobra.Command{
@@ -18,6 +21,7 @@ constraints and finally the indexes are created.`,
 
 		var (
 			d   *datadirectory.DataDirectory
+			cfg *datadirectory.Config
 			db  *database.Database
 			arg string
 			err error
@@ -37,15 +41,78 @@ constraints and finally the indexes are created.`,
 			log.Fatal("load requires a dburi")
 		}
 
+		// Enforce required schema.
+		if viper.GetString("schema") == "" {
+			log.Fatal("load requires a schema")
+		}
+
 		log.WithFields(log.Fields{
 			"directory": arg,
 		}).Info("beginning dataset loading")
 
 		// Make the DataDirectory object and load it from the metadata file,
 		// see cmd/validate.go for that process.
+		cfg = &datadirectory.Config{DataDirPath: arg}
+		d, err = datadirectory.New(cfg)
+		if err != nil {
+			log.Fatal(fmt.Sprintf("Error reading data directory: %v", err))
+		}
+
+		err = d.ReadMetadataFromFile()
+		if err != nil {
+			log.Fatal(fmt.Sprintf("Error reading metadata file: %v", err))
+		}
+
+		// The data model in the data directory can be overridden by the
+		// --model command line switch. E.g. the non-vocbulary `pedsnet`
+		// data model is ordinarily overridden as `--model=pedsnet-core`,
+		// and the vocabulary is overridden as `--model=pedsnet-vocab`
+
+		dataModel := d.Model
+		if viper.GetString("model") != "" {
+			dataModel = viper.GetString("model")
+		}
+
+		modelVersion := d.ModelVersion
+		if viper.GetString("modelv") != "" {
+			modelVersion = viper.GetString("modelv")
+		}
 
 		// Open the Database object using information from the DataDirectory
 		// object. Create tables and load data, then constraints and indexes.
+
+		// TODO: should we enforce (in validate) that all models and model
+		// versions in the metadata file are the same, and in
+		// datadirectory, should ReadMetadataFromFile set the model and
+		// model version in the datadirectory object? Eh, probably not.
+		// We should loop over the metadata, opening the database for each
+		// table we load.
+
+		logFields := log.Fields{
+			"DataModel":    dataModel,
+			"ModelVersion": modelVersion,
+			"DbUrl":        viper.GetString("dburi"),
+			"Schema":       viper.GetString("schema"),
+			"Service":      viper.GetString("service"),
+		}
+
+		db, err = database.Open(dataModel, modelVersion, viper.GetString("dburi"), viper.GetString("schema"), viper.GetString("dmsaservice"), "", "")
+		if err != nil {
+			logFields["err"] = err.Error()
+			log.WithFields(logFields).Fatal("Database Open failed")
+		}
+
+		err = db.CreateTables()
+		if err != nil {
+			logFields["err"] = err.Error()
+			log.WithFields(logFields).Fatal("CreateTables() failed")
+		}
+
+		err = db.Load(d)
+		if err != nil {
+			logFields["err"] = err.Error()
+			log.WithFields(logFields).Fatal("Load() failed")
+		}
 
 		// TODO: figure out password handling that does not involve entering
 		// it into a command line.
@@ -60,11 +127,13 @@ func init() {
 	// Register this command under the top-level CLI command.
 	RootCmd.AddCommand(loadCmd)
 
-	// Set up the expand-command-specific flags.
+	// Set up the load-command-specific flags.
 	loadCmd.Flags().StringP("dburi", "d", "", "Database URI to load the dataset into. Required.")
 	loadCmd.Flags().StringP("dbpass", "p", "", "Database password.")
+	loadCmd.Flags().StringP("schema", "s", "", "Schema into which to load. Required.")
 
 	// Bind viper keys to the flag values.
 	viper.BindPFlag("dburi", loadCmd.Flags().Lookup("dburi"))
 	viper.BindPFlag("dbpass", loadCmd.Flags().Lookup("dbpass"))
+	viper.BindPFlag("schema", loadCmd.Flags().Lookup("schema"))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ func init() {
 	// Set up global flags that can be specified at any point on the command
 	// line. The values and defaults will be managed by viper.
 	RootCmd.PersistentFlags().String("service", "", "Data models service URL.")
+	RootCmd.PersistentFlags().String("dmsaservice", "", "Data models SQLAlchemy service URL.")
 	RootCmd.PersistentFlags().StringP("model", "m", "", "Data model of the dataset.")
 	RootCmd.PersistentFlags().StringP("modelv", "v", "", "Data model version number.")
 	RootCmd.PersistentFlags().String("loglvl", "", "Logging output level  [DEBUG|INFO|WARN|ERROR|FATAL].")
@@ -58,6 +59,7 @@ func init() {
 
 	// Bind viper key names to the global flags.
 	viper.BindPFlag("service", RootCmd.PersistentFlags().Lookup("service"))
+	viper.BindPFlag("dmsaservice", RootCmd.PersistentFlags().Lookup("dmsaservice"))
 	viper.BindPFlag("model", RootCmd.PersistentFlags().Lookup("model"))
 	viper.BindPFlag("modelv", RootCmd.PersistentFlags().Lookup("modelv"))
 	viper.BindPFlag("loglvl", RootCmd.PersistentFlags().Lookup("loglvl"))
@@ -65,6 +67,7 @@ func init() {
 
 	// Set defaults in viper.
 	viper.SetDefault("service", "https://data-models-service.research.chop.edu/")
+	viper.SetDefault("dmsaservice", "https://data-models-sqlalchemy.research.chop.edu/")
 	viper.SetDefault("loglvl", "INFO")
 	if !log.IsTerminal() {
 		// Default to json instead of logrus default text when no tty attached.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,11 @@ func init() {
 	RootCmd.PersistentFlags().String("loglvl", "", "Logging output level  [DEBUG|INFO|WARN|ERROR|FATAL].")
 	RootCmd.PersistentFlags().String("logfmt", "", "Logging output format [tty|text|json].")
 
+	// Flags for constrain and load -- seemingly subcommands can't share flags with out the flags being global.  See https://github.com/spf13/cobra/issues/277.
+	RootCmd.PersistentFlags().StringP("dburi", "d", "", "Database URI to load the dataset into. Required by load, constrain.")
+	RootCmd.PersistentFlags().StringP("searchPath", "s", "", "SearchPath for the load (secondary schemas may be needed for adding constraints). Required by load, constrain.")
+	RootCmd.PersistentFlags().Bool("undo", false, "Undo the load; delete all tables.")
+
 	// Bind viper key names to the global flags.
 	viper.BindPFlag("service", RootCmd.PersistentFlags().Lookup("service"))
 	viper.BindPFlag("dmsaservice", RootCmd.PersistentFlags().Lookup("dmsaservice"))
@@ -64,6 +69,11 @@ func init() {
 	viper.BindPFlag("modelv", RootCmd.PersistentFlags().Lookup("modelv"))
 	viper.BindPFlag("loglvl", RootCmd.PersistentFlags().Lookup("loglvl"))
 	viper.BindPFlag("logfmt", RootCmd.PersistentFlags().Lookup("logfmt"))
+
+	// Viper flag bindings for constrain and load.
+	viper.BindPFlag("dburi", RootCmd.PersistentFlags().Lookup("dburi"))
+	viper.BindPFlag("searchPath", RootCmd.PersistentFlags().Lookup("searchPath"))
+	viper.BindPFlag("undo", RootCmd.PersistentFlags().Lookup("undo"))
 
 	// Set defaults in viper.
 	viper.SetDefault("service", "https://data-models-service.research.chop.edu/")
@@ -73,6 +83,10 @@ func init() {
 		// Default to json instead of logrus default text when no tty attached.
 		viper.SetDefault("logfmt", "json")
 	}
+
+	viper.SetDefault("dburi", "")
+	viper.SetDefault("searchPath", "")
+	viper.SetDefault("undo", false)
 
 	// Set up the dummy version flag. It will actually be handled in the
 	// main.main function, but we want it to show up in the help.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/infomodels/database"
+)
+
+func getModelAndVersion(dburi string, searchPath string) (model string, modelVersion string, err error) {
+	var (
+		db *sql.DB
+	)
+
+	db, err = database.OpenDatabase(dburi, searchPath)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+
+	// From the version_history table, return the model and
+	// model_version from the last 'create tables' entry such that there
+	// is no 'drop tables' entry after the final 'create tables' entry.
+	query := `
+with last_create as
+(select * from version_history
+where operation = 'create tables'
+order by datetime desc
+limit 1),
+last_drop as
+(select * from version_history
+where operation = 'drop tables'
+order by datetime desc
+limit 1)
+select model, model_version from
+(select last_create.model, last_create.model_version, last_create.datetime as last_create_time, last_drop.datetime as last_drop_time from last_create
+left join last_drop on 1 = 1) q
+where case when last_drop_time is null then true when last_create_time > last_drop_time then true else false end;
+  `
+	err = db.QueryRow(query).Scan(&model, &modelVersion)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			err = fmt.Errorf("Can't determine model and version because no active 'create tables' operation in version_history table (search_path %s)", searchPath)
+		} else {
+			return
+		}
+	}
+
+	return
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -91,8 +91,13 @@ the model definition.`,
 
 		// Hack to get Model and ModelVersion actually on to the DataDirectory
 		// object, should be done by library.
-		d.Model = d.RecordMaps[0]["cdm"]
-		d.ModelVersion = d.RecordMaps[0]["cdm-version"]
+		// Kevin's hack: command-line args should override file-based configuration
+		if d.Model == "" {
+			d.Model = d.RecordMaps[0]["cdm"]
+		}
+		if d.ModelVersion == "" {
+			d.ModelVersion = d.RecordMaps[0]["cdm-version"]
+		}
 
 		// Validate metadata information and checksums, fatal and exit on err.
 		// This checks the attributes on the DataDirectory object (any command


### PR DESCRIPTION
Rush-job load and constrain commands as used for the initial v2.3 PEDSnet pre-DQA loads.

Known TODO items:
*) Fix dburi, searchPath, and undo flags to not be global.
*) Retool when database.go is rewritten.
*) Add command-line password support.

Usage notes: https://github.research.chop.edu/dbhi/pedsnet/issues/143#issuecomment-4186
